### PR TITLE
fix: add event handler to the button, close #2

### DIFF
--- a/interactive-card-details-form-main/react-ts-tailwind/src/components/CompletedPanel.tsx
+++ b/interactive-card-details-form-main/react-ts-tailwind/src/components/CompletedPanel.tsx
@@ -13,6 +13,7 @@ function CompletedPanel() {
             <button
                 type="button"
                 className="mt-12 h-[53px] w-full rounded-[8px] bg-button text-[18px] leading-[normal] text-button-text"
+                onClick={() => window.location.reload()}
             >
                 Continue
             </button>


### PR DESCRIPTION
The issue was fixed by adding an onClick event handler to the button to reload the page.